### PR TITLE
Fix scaling bug in level editor

### DIFF
--- a/editor/script.js
+++ b/editor/script.js
@@ -1504,7 +1504,7 @@ function resized(){
     let height = window.innerHeight * .00078
 
     document.documentElement.style.setProperty("--scaleWidth", width)
-    document.documentElement.style.setProperty("--scaleHieght", height)
+    document.documentElement.style.setProperty("--scaleHeight", height)
 }
 
 window.onresize = function() {

--- a/editor/style.css
+++ b/editor/style.css
@@ -76,7 +76,7 @@ td .candy_cannon {
 }
 
 #level {
-    transform: scale(var(--scaleWidth 1, --scaleHeight));
+    transform: scale(var(--scaleWidth, 1), var(--scaleHeight, 1));
     z-index: 10;
     color: white;
     margin-left: auto;


### PR DESCRIPTION
## Summary
- fix CSS variable typo in script.js so height scaling works
- correct `transform: scale()` syntax in style.css